### PR TITLE
Issue 86 customer realm scopes

### DIFF
--- a/src/main/java/org/zalando/planb/provider/AuthorizeController.java
+++ b/src/main/java/org/zalando/planb/provider/AuthorizeController.java
@@ -199,6 +199,9 @@ public class AuthorizeController {
         final Set<String> scopes = ScopeProperties.split(scope);
         final Set<String> defaultScopes = scopeProperties.getDefaultScopes(realmName);
         final Set<String> finalScopes = scopes.isEmpty() ? defaultScopes : scopes;
+        // IMPORTANT: make sure that the requested scopes are allowed by the client
+        // (implicit flow does not authenticate the client, so it would not be checked otherwise)
+        clientRealm.validateScopes(clientId, clientData, finalScopes, defaultScopes);
         final UserRealm userRealm = realms.getUserRealm(realmName);
 
         URI redirect;

--- a/src/main/java/org/zalando/planb/provider/realms/ClientManagedRealm.java
+++ b/src/main/java/org/zalando/planb/provider/realms/ClientManagedRealm.java
@@ -23,14 +23,7 @@ public interface ClientManagedRealm extends ClientRealm {
             throw wrongClientSecret(clientId, getName());
         }
 
-        final Set<String> missingScopes = scopes.stream()
-                .filter(scope -> !defaultScopes.contains(scope))
-                .filter(scope -> !client.getScopes().contains(scope))
-                .collect(toSet());
-
-        if (!missingScopes.isEmpty()) {
-            throw new ClientRealmAuthorizationException(clientId, getName(), missingScopes);
-        }
+        validateScopes(clientId, client, scopes, defaultScopes);
     }
 
     void update(String clientId, ClientData data) throws NotFoundException;

--- a/src/main/java/org/zalando/planb/provider/realms/ClientRealm.java
+++ b/src/main/java/org/zalando/planb/provider/realms/ClientRealm.java
@@ -5,7 +5,20 @@ import org.zalando.planb.provider.ClientData;
 import java.util.Optional;
 import java.util.Set;
 
+import static java.util.stream.Collectors.toSet;
+
 public interface ClientRealm extends Realm {
+
+    default void validateScopes(String clientId, ClientData client, Set<String> requestedScopes, Set<String> defaultScopes) {
+        final Set<String> missingScopes = requestedScopes.stream()
+                .filter(scope -> !defaultScopes.contains(scope))
+                .filter(scope -> !client.getScopes().contains(scope))
+                .collect(toSet());
+
+        if (!missingScopes.isEmpty()) {
+            throw new ClientRealmAuthorizationException(clientId, getName(), missingScopes);
+        }
+    }
 
     void authenticate(String clientId, String clientSecret, Set<String> scopes, Set<String> defaultScopes)
             throws ClientRealmAuthenticationException, ClientRealmAuthorizationException;

--- a/src/test/java/org/zalando/planb/provider/ImplicitGrantFlowIT.java
+++ b/src/test/java/org/zalando/planb/provider/ImplicitGrantFlowIT.java
@@ -210,11 +210,11 @@ public class ImplicitGrantFlowIT extends AbstractOauthTest {
         requestParameters.add("redirect_uri", "https://myapp.example.org/callback");
 
         RequestEntity<MultiValueMap<String, Object>> request = RequestEntity
-                .post(URI.create("http://localhost:" + port + "/oauth2/authorize"))
+                .post(URI.create("http://localhost:" + getPort() + "/oauth2/authorize"))
                 .accept(MediaType.APPLICATION_JSON)
                 .body(requestParameters);
 
-        ResponseEntity<AuthorizeResponse> loginResponse = rest.exchange(request, AuthorizeResponse.class);
+        ResponseEntity<AuthorizeResponse> loginResponse = getRestTemplate().exchange(request, AuthorizeResponse.class);
         assertThat(loginResponse.getBody().getClientName()).isEqualTo("Test Customer App");
         assertThat(loginResponse.getBody().getScopes()).containsExactly("uid", "read-customer-profile");
     }
@@ -233,11 +233,11 @@ public class ImplicitGrantFlowIT extends AbstractOauthTest {
         requestParameters.add("redirect_uri", "https://myapp.example.org/callback");
 
         RequestEntity<MultiValueMap<String, Object>> request = RequestEntity
-                .post(URI.create("http://localhost:" + port + "/oauth2/authorize"))
+                .post(URI.create("http://localhost:" + getPort() + "/oauth2/authorize"))
                 .body(requestParameters);
 
         try {
-            rest.exchange(request, Void.class);
+            getRestTemplate().exchange(request, Void.class);
             fail("Implicit Grant flow should restrict scopes by client");
         } catch (HttpClientErrorException ex) {
             assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);

--- a/src/test/resources/testdata.cql
+++ b/src/test/resources/testdata.cql
@@ -24,9 +24,9 @@ INSERT INTO provider.user (username, realm, password_hashes, scopes, created_by,
     VALUES ('testuser', '/services', { {password_hash: '$2b$04$iXpLcLet3KbvJ2MOEnd49u6sMTBAfRlLc43kehrCI.3OWbkIGcS7K', created: 123, created_by: 'testdata.cql'} },
             {'uid': 'uidval', 'ascope': 'ascopeval', 'useronly': 'useronlyval', 'openid': 'yes'}, '/services/user1', '/services/user1');
 
-INSERT INTO provider.client (client_id, realm, client_secret_hash, scopes, is_confidential, redirect_uris, created_by, last_modified_by)
+INSERT INTO provider.client (client_id, realm, client_secret_hash, scopes, is_confidential, name, redirect_uris, created_by, last_modified_by)
     VALUES ('testcustomerimplicit', '/customers', '$2b$04$iXpLcLet3KbvJ2MOEnd49u6sMTBAfRlLc43kehrCI.3OWbkIGcS7K',
-            {'uid', 'read-customer-profile'}, false, {'https://myapp.example.org/callback'}, '/services/user1', '/services/user1');
+            {'uid', 'read-customer-profile'}, false, 'Test Customer App', {'https://myapp.example.org/callback'}, '/services/user1', '/services/user1');
 
 -- default keys
 

--- a/src/test/resources/testdata.cql
+++ b/src/test/resources/testdata.cql
@@ -24,6 +24,10 @@ INSERT INTO provider.user (username, realm, password_hashes, scopes, created_by,
     VALUES ('testuser', '/services', { {password_hash: '$2b$04$iXpLcLet3KbvJ2MOEnd49u6sMTBAfRlLc43kehrCI.3OWbkIGcS7K', created: 123, created_by: 'testdata.cql'} },
             {'uid': 'uidval', 'ascope': 'ascopeval', 'useronly': 'useronlyval', 'openid': 'yes'}, '/services/user1', '/services/user1');
 
+INSERT INTO provider.client (client_id, realm, client_secret_hash, scopes, is_confidential, redirect_uris, created_by, last_modified_by)
+    VALUES ('testcustomerimplicit', '/customers', '$2b$04$iXpLcLet3KbvJ2MOEnd49u6sMTBAfRlLc43kehrCI.3OWbkIGcS7K',
+            {'uid', 'read-customer-profile'}, false, {'https://myapp.example.org/callback'}, '/services/user1', '/services/user1');
+
 -- default keys
 
 INSERT INTO provider.keypair (kid, realms, private_key_pem, algorithm, valid_from)


### PR DESCRIPTION
Fixes #86:

* make sure that customer realm can request any scope allowed by client
* make sure that customer realm cannot request more scopes than allowed by client (important for implicit grant flow where no client authentication takes place)