### PR TITLE
Issue-92: Configurable token lifetime per realm

### DIFF
--- a/src/main/java/org/zalando/planb/provider/AuthorizeController.java
+++ b/src/main/java/org/zalando/planb/provider/AuthorizeController.java
@@ -82,6 +82,9 @@ public class AuthorizeController {
     private RealmConfig realms;
 
     @Autowired
+    private RealmProperties realmProperties;
+
+    @Autowired
     private JWTIssuer jwtIssuer;
 
     @Autowired
@@ -365,7 +368,7 @@ public class AuthorizeController {
 
         final String rawJWT = jwtIssuer.issueAccessToken(userRealm, clientId, finalScopes, claims);
         return new URIBuilder(redirectUri).addParameter(PARAM_ACCESS_TOKEN, rawJWT).addParameter(PARAM_TOKEN_TYPE, PARAM_TOKEN_TYPE_BEARER)
-                .addParameter(PARAM_EXPIRES_IN, String.valueOf(JWTIssuer.EXPIRATION_TIME.getSeconds()))
+                .addParameter(PARAM_EXPIRES_IN, String.valueOf(realmProperties.getTokenLifetime(userRealm.getName()).getSeconds()))
                 .addParameter(PARAM_SCOPE, ScopeService.join(finalScopes))
                 .addParameter(PARAM_STATE, state.orElse(EMPTY_STRING)).build();
     }

--- a/src/main/java/org/zalando/planb/provider/JWTIssuer.java
+++ b/src/main/java/org/zalando/planb/provider/JWTIssuer.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.zalando.planb.provider.realms.Realm;
 
-import java.time.Duration;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
@@ -26,7 +25,8 @@ public class JWTIssuer {
     private static final String ISSUER = "B";
     private static final String AUTHORIZED_PARTY = "azp";
 
-    public static final Duration EXPIRATION_TIME = Duration.ofHours(8);
+    @Autowired
+    private RealmProperties realmProperties;
 
     @Autowired
     private OIDCKeyHolder keyHolder;
@@ -63,10 +63,10 @@ public class JWTIssuer {
     public String issueAccessToken(Realm userRealm, String clientId, Set<String> scopes, Map<String, String> claims) throws JOSEException {
         // this should never happen (only if some realm does not return "sub"
         Preconditions.checkState(claims.containsKey(Realm.SUB), "'sub' claim missing");
-
+        final long tokenLifetimeInMilliseconds = realmProperties.getTokenLifetime(userRealm.getName()).toMillis();
         JWTClaimsSet.Builder claimsBuilder = new JWTClaimsSet.Builder()
                 .issuer(ISSUER)
-                .expirationTime(new Date(System.currentTimeMillis() + EXPIRATION_TIME.toMillis()))
+                .expirationTime(new Date(System.currentTimeMillis() + tokenLifetimeInMilliseconds))
                 .issueTime(new Date())
                 .claim("realm", userRealm.getName())
                 .claim("scope", scopes);

--- a/src/main/java/org/zalando/planb/provider/OIDCController.java
+++ b/src/main/java/org/zalando/planb/provider/OIDCController.java
@@ -11,7 +11,11 @@ import org.springframework.web.bind.annotation.*;
 import org.zalando.planb.provider.realms.*;
 
 import java.net.URI;
-import java.util.*;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -29,6 +33,9 @@ public class OIDCController {
 
     @Autowired
     private RealmConfig realms;
+
+    @Autowired
+    private RealmProperties realmProperties;
 
     @Autowired
     private OIDCKeyHolder keyHolder;
@@ -82,11 +89,11 @@ public class OIDCController {
                 .orElseThrow(() -> new RealmNotFoundException(realmNameParam));
     }
 
-    static OIDCCreateTokenResponse response(String accessToken, Set<String> scopes, String realmName) {
+    private OIDCCreateTokenResponse response(String accessToken, Set<String> scopes, String realmName) {
         return OIDCCreateTokenResponse.builder()
                 .accessToken(accessToken)
                 .idToken(scopes.contains("openid") ? accessToken : (String)null)
-                .expiresIn(JWTIssuer.EXPIRATION_TIME.getSeconds())
+                .expiresIn(realmProperties.getTokenLifetime(realmName).getSeconds())
                 .scope(ScopeService.join(scopes))
                 .realm(realmName)
                 .build();

--- a/src/main/java/org/zalando/planb/provider/RealmProperties.java
+++ b/src/main/java/org/zalando/planb/provider/RealmProperties.java
@@ -4,17 +4,24 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.zalando.planb.provider.realms.ClientRealm;
 import org.zalando.planb.provider.realms.UserRealm;
 
-import java.util.*;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 
 @ConfigurationProperties(prefix = "realm")
 public class RealmProperties {
 
-    private List<String> names = new ArrayList<String>();
+    private static final Duration DEFAULT_TOKEN_LIFETIME = Duration.ofHours(8);
+
+    private List<String> names = new ArrayList<>();
 
     private Map<String, Class<? extends ClientRealm>> clientImpl = new TreeMap<>(CASE_INSENSITIVE_ORDER);
     private Map<String, Class<? extends UserRealm>> userImpl = new TreeMap<>(CASE_INSENSITIVE_ORDER);
+    private Map<String, Duration> tokenLifetime = new TreeMap<>(CASE_INSENSITIVE_ORDER);
 
     public List<String> getNames() {
         return names;
@@ -32,8 +39,22 @@ public class RealmProperties {
     public Map<String, Class<? extends UserRealm>> getUserImpl() {
         return userImpl;
     }
+
     public Class<? extends UserRealm> getUserImpl(String realmName, Class<? extends UserRealm> defaultImpl) {
         // try realm name also without slash (necessary to support config via simple environment variables!)
         return userImpl.getOrDefault(realmName, userImpl.getOrDefault(RealmConfig.stripLeadingSlash(realmName), defaultImpl));
+    }
+
+    public Map<String, Duration> getTokenLifetime() {
+        return tokenLifetime;
+    }
+
+    public Duration getTokenLifetime(String realmName, Duration defaultTokenLifetime) {
+        // try realm name also without slash (necessary to support config via simple environment variables!)
+        return tokenLifetime.getOrDefault(realmName, tokenLifetime.getOrDefault(RealmConfig.stripLeadingSlash(realmName), defaultTokenLifetime));
+    }
+
+    public Duration getTokenLifetime(String realmName) {
+        return getTokenLifetime(realmName, DEFAULT_TOKEN_LIFETIME);
     }
 }

--- a/src/main/java/org/zalando/planb/provider/StringToDurationConverter.java
+++ b/src/main/java/org/zalando/planb/provider/StringToDurationConverter.java
@@ -1,0 +1,17 @@
+package org.zalando.planb.provider;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@ConfigurationPropertiesBinding
+public class StringToDurationConverter implements Converter<String, Duration> {
+
+    @Override
+    public Duration convert(String source) {
+        return Duration.parse(source);
+    }
+}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -29,6 +29,10 @@ realm:
   userImpl:
     /employees: org.zalando.planb.provider.realms.UpstreamUserRealm
     /customers: org.zalando.planb.provider.realms.CustomerUserRealm
+  tokenLifetime:
+    /employees: "PT8H"
+    /customers: "P30D"
+    /services: "PT8H"
 
 cassandra:
   keyspace: provider

--- a/src/test/java/org/zalando/planb/provider/ImplicitGrantFlowIT.java
+++ b/src/test/java/org/zalando/planb/provider/ImplicitGrantFlowIT.java
@@ -100,7 +100,7 @@ public class ImplicitGrantFlowIT extends AbstractOauthTest {
         // check required parameters
         assertThat(params).containsKey("access_token");
         assertThat(params).contains(MapEntry.entry("token_type", "Bearer"));
-        assertThat(params).contains(MapEntry.entry("expires_in", "28800")); // 8 hours
+        assertThat(params).contains(MapEntry.entry("expires_in", "3600"));
         assertThat(params).containsKey("scope");
         assertThat(params).containsKey("state");
     }
@@ -137,7 +137,7 @@ public class ImplicitGrantFlowIT extends AbstractOauthTest {
         // check required parameters
         assertThat(params).containsKey("access_token");
         assertThat(params).contains(MapEntry.entry("token_type", "Bearer"));
-        assertThat(params).contains(MapEntry.entry("expires_in", "28800")); // 8 hours
+        assertThat(params).contains(MapEntry.entry("expires_in", "3600"));
         assertThat(params).containsKey("scope");
         assertThat(params).containsKey("state");
     }
@@ -174,31 +174,12 @@ public class ImplicitGrantFlowIT extends AbstractOauthTest {
         assertThat(params).containsKey("state");
     }
 
-    String stubCustomerService() {
-        final String customerNumber = "123456789";
-        stubFor(post(urlEqualTo("/ws/customerService?wsdl"))
-                .willReturn(aResponse()
-                        .withStatus(OK.value())
-                        .withHeader(ContentTypeHeader.KEY, TEXT_XML_VALUE)
-                        .withBody("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
-                                "    <soap:Body>\n" +
-                                "        <ns2:authenticateResponse xmlns:ns2=\"http://service.webservice.customer.zalando.de/\">\n" +
-                                "            <return>\n" +
-                                "                <customerNumber>" + customerNumber + "</customerNumber>\n" +
-                                "                <loginResult>SUCCESS</loginResult>\n" +
-                                "            </return>\n" +
-                                "        </ns2:authenticateResponse>\n" +
-                                "    </soap:Body>\n" +
-                                "</soap:Envelope>")));
-        return customerNumber;
-    }
-
     /**
      * Verify https://github.com/zalando/planb-provider/issues/86
      */
     @Test
     public void customerScopeAllowedByClient() {
-        final String customerNumber = stubCustomerService();
+        stubCustomerService();
 
         MultiValueMap<String, Object> requestParameters = new LinkedMultiValueMap<>();
         requestParameters.add("response_type", "token");

--- a/src/test/java/org/zalando/planb/provider/OIDCCreateTokenIT.java
+++ b/src/test/java/org/zalando/planb/provider/OIDCCreateTokenIT.java
@@ -42,26 +42,6 @@ import static org.springframework.http.MediaType.TEXT_XML_VALUE;
 @ActiveProfiles("it")
 public class OIDCCreateTokenIT extends AbstractOauthTest {
 
-    private ResponseEntity<OIDCCreateTokenResponse> createToken(String realm, String clientId, String clientSecret,
-                                                                String username, String password, String scope) {
-        MultiValueMap<String, Object> requestParameters = new LinkedMultiValueMap<>();
-        requestParameters.add("realm", realm);
-        requestParameters.add("grant_type", "password");
-        requestParameters.add("username", username);
-        requestParameters.add("password", password);
-        if (scope != null) {
-            requestParameters.add("scope", scope);
-        }
-        String basicAuth = Base64.getEncoder().encodeToString((clientId + ':' + clientSecret).getBytes(UTF_8));
-
-        RequestEntity<MultiValueMap<String, Object>> request = RequestEntity
-                .post(getAccessTokenUri())
-                .header("Authorization", "Basic " + basicAuth)
-                .body(requestParameters);
-
-        return getRestTemplate().exchange(request, OIDCCreateTokenResponse.class);
-    }
-
     @Test
     public void createServiceUserToken() {
         ResponseEntity<OIDCCreateTokenResponse> response = createToken("/services",
@@ -216,25 +196,6 @@ public class OIDCCreateTokenIT extends AbstractOauthTest {
         assertThat(jwt.getJWTClaimsSet().getStringClaim("realm")).isEqualTo("/customers");
         assertThat(jwt.getJWTClaimsSet().getStringClaim("iss")).isEqualTo("B");
         assertThat(jwt.getJWTClaimsSet().getStringListClaim("scope")).containsExactly("uid", "openid");
-    }
-
-    String stubCustomerService() {
-        final String customerNumber = "123456789";
-        stubFor(post(urlEqualTo("/ws/customerService?wsdl"))
-                .willReturn(aResponse()
-                        .withStatus(OK.value())
-                        .withHeader(ContentTypeHeader.KEY, TEXT_XML_VALUE)
-                        .withBody("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
-                                "    <soap:Body>\n" +
-                                "        <ns2:authenticateResponse xmlns:ns2=\"http://service.webservice.customer.zalando.de/\">\n" +
-                                "            <return>\n" +
-                                "                <customerNumber>" + customerNumber + "</customerNumber>\n" +
-                                "                <loginResult>SUCCESS</loginResult>\n" +
-                                "            </return>\n" +
-                                "        </ns2:authenticateResponse>\n" +
-                                "    </soap:Body>\n" +
-                                "</soap:Envelope>")));
-        return customerNumber;
     }
 
     @Test

--- a/src/test/java/org/zalando/planb/provider/TokenLifetimeIT.java
+++ b/src/test/java/org/zalando/planb/provider/TokenLifetimeIT.java
@@ -1,0 +1,30 @@
+package org.zalando.planb.provider;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("it")
+public class TokenLifetimeIT extends AbstractOauthTest {
+
+    @Autowired
+    private RealmProperties realmProperties;
+
+    @Test
+    public void testTokenLifetimeIsOverriden() {
+        ResponseEntity<OIDCCreateTokenResponse> response = createToken("/services",
+                "testclient", "test", "testuser", "test", "uid ascope");
+
+        assertThat(response.getBody().getExpiresIn()).isEqualTo(3600);
+    }
+
+    @Test
+    public void testTokenLifetimeFallsbackToDefault() {
+        assertThat(realmProperties.getTokenLifetime("/foo")).isEqualTo(Duration.ofHours(8));
+    }
+}

--- a/src/test/resources/config/application-it.yml
+++ b/src/test/resources/config/application-it.yml
@@ -27,3 +27,7 @@ scope:
   defaults:
     services: "hello world"
     customers: "openid"
+
+realm:
+  tokenLifetime:
+    /services: "PT3600S"


### PR DESCRIPTION
- RealmProperties now exposes realm-specific token duration
- Modified default customer realm token duration to 30 days
- Some refactoring in integration-test classes
- Cleaned up some import *
- Added StringToDurationConverter to support java Duration in properties file