### PR TITLE
Issue #113: Default scopes for service clients does not work via reource owner password grant.

### DIFF
--- a/src/main/java/org/zalando/planb/provider/OIDCController.java
+++ b/src/main/java/org/zalando/planb/provider/OIDCController.java
@@ -187,15 +187,15 @@ public class OIDCController {
             // retrieve realms for the given realm
             ClientRealm clientRealm = realms.getClientRealm(realmName);
             UserRealm userRealm = realms.getUserRealm(realmName);
+            final ClientCredentials clientCredentials = getClientCredentials(authorization, clientIdParam, clientSecretParam);
 
             // parse requested scopes
             final Set<String> scopes = ScopeService.split(scope);
-            final Set<String> defaultScopes = scopeService.getDefaultScopesForClient(clientRealm, clientIdParam);
+            final Set<String> defaultScopes = scopeService.getDefaultScopesForClient(clientRealm, clientCredentials.getClientId());
             final Set<String> finalScopes = scopes.isEmpty() ? defaultScopes : scopes;
 
-            final ClientCredentials clientCredentials = getClientCredentials(authorization, clientIdParam, clientSecretParam);
-            clientRealm.authenticate(clientCredentials.getClientId(), clientCredentials.getClientSecret(), scopes, defaultScopes);
-            final Map<String, String> extraClaims = userRealm.authenticate(username, password, scopes, defaultScopes);
+            clientRealm.authenticate(clientCredentials.getClientId(), clientCredentials.getClientSecret(), finalScopes, defaultScopes);
+            final Map<String, String> extraClaims = userRealm.authenticate(username, password, finalScopes, defaultScopes);
 
             // request authorized, create JWT
             final String rawJWT = jwtIssuer.issueAccessToken(userRealm, clientCredentials.getClientId(), finalScopes, extraClaims);

--- a/src/main/java/org/zalando/planb/provider/ScopeService.java
+++ b/src/main/java/org/zalando/planb/provider/ScopeService.java
@@ -32,12 +32,6 @@ public class ScopeService {
                 .orElse(getDefaultScopesByRealm(clientRealm.getName()));
     }
 
-    public Set<String> getDefaultScopesForClient(final ClientRealm clientRealm, final Optional<String> clientId) {
-        return clientId
-                .map((theClientId) -> getDefaultScopesForClient(clientRealm, theClientId))
-                .orElse(getDefaultScopesByRealm(clientRealm.getName()));
-    }
-
     public Set<String> getDefaultScopesByRealm(String realm) {
         return split(Optional.ofNullable(realm)
                 .map(RealmConfig::stripLeadingSlash)

--- a/src/test/java/org/zalando/planb/provider/DefaultScopeIT.java
+++ b/src/test/java/org/zalando/planb/provider/DefaultScopeIT.java
@@ -8,7 +8,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.RequestEntity.post;
 
 @ActiveProfiles("it")
 public class DefaultScopeIT extends AbstractOauthTest {
@@ -30,6 +34,26 @@ public class DefaultScopeIT extends AbstractOauthTest {
 
         ResponseEntity<AuthorizeResponse> loginResponse = getRestTemplate().exchange(request, AuthorizeResponse.class);
         assertThat(loginResponse.getBody().getScopes()).containsExactly("uid");
+    }
+
+    @Test
+    public void clientSpecificDefaultsResourceOwnerPasswordGrantTest() {
+        MultiValueMap<String, Object> requestParameters = new LinkedMultiValueMap<>();
+        requestParameters.add("grant_type", "password");
+        requestParameters.add("realm", "/services");
+        requestParameters.add("username", "testuser");
+        requestParameters.add("password", "test");
+
+        String basicAuth = Base64.getEncoder().encodeToString(("testdefaultscope" + ':' + "test").getBytes(UTF_8));
+
+        RequestEntity<MultiValueMap<String, Object>> request =
+                post(getAccessTokenUri())
+                        .header("Authorization", "Basic " + basicAuth)
+                        .body(requestParameters);
+
+        ResponseEntity<OIDCCreateTokenResponse> loginResponse = getRestTemplate().exchange(request, OIDCCreateTokenResponse.class);
+        assertThat(loginResponse.getBody().getRealm()).isEqualTo("/services");
+        assertThat(loginResponse.getBody().getScope()).isEqualTo("uid");
     }
 
     @Test

--- a/src/test/resources/testdata.cql
+++ b/src/test/resources/testdata.cql
@@ -24,6 +24,9 @@ INSERT INTO provider.client (client_id, realm, client_secret_hash, scopes, defau
     VALUES ('testdefaultscope', '/services', '$2b$04$iXpLcLet3KbvJ2MOEnd49u6sMTBAfRlLc43kehrCI.3OWbkIGcS7K',
             {'uid', 'ascope', 'clientonly'}, {'uid'}, false, {'https://myapp.example.org/callback'}, '/services/user1', '/services/user1');
 
+INSERT INTO provider.user (username, realm, password_hashes, scopes, created_by, last_modified_by)
+    VALUES ('testdefaultscope', '/services', { {password_hash: '$2b$04$iXpLcLet3KbvJ2MOEnd49u6sMTBAfRlLc43kehrCI.3OWbkIGcS7K', created: 123, created_by: 'testdata.cql'} },
+            {'uid': 'true'}, '/services/testdefaultscope', '/services/testdefaultscope');
 
 INSERT INTO provider.user (username, realm, password_hashes, scopes, created_by, last_modified_by)
     VALUES ('testuser', '/services', { {password_hash: '$2b$04$iXpLcLet3KbvJ2MOEnd49u6sMTBAfRlLc43kehrCI.3OWbkIGcS7K', created: 123, created_by: 'testdata.cql'} },


### PR DESCRIPTION
- Added integration test that demonstrates default scopes for resource owner password grant
- Fixed issue on OIDCController, improper client credentials where being passed to ScopeService