### PR TITLE
Issue #115: token_type is present in the body of resource owner password grant response.

### DIFF
--- a/src/main/java/org/zalando/planb/provider/AuthorizeController.java
+++ b/src/main/java/org/zalando/planb/provider/AuthorizeController.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.utils.URIBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -75,7 +76,6 @@ public class AuthorizeController {
     private static final String PARAM_RESPONSE_TYPE_TOKEN = "token";
     private static final String PARAM_STATE = "state";
     private static final String PARAM_TOKEN_TYPE = "token_type";
-    private static final String PARAM_TOKEN_TYPE_BEARER = "Bearer";
     private static final String PARAM_USERNAME = "username";
 
     private static final Set<String> SUPPORTED_RESPONSE_TYPES = ImmutableSet.of(PARAM_RESPONSE_TYPE_CODE, PARAM_RESPONSE_TYPE_TOKEN);
@@ -374,7 +374,7 @@ public class AuthorizeController {
 
         final URI queryURI = new URIBuilder()
                 .addParameter(PARAM_ACCESS_TOKEN, rawJWT)
-                .addParameter(PARAM_TOKEN_TYPE, PARAM_TOKEN_TYPE_BEARER)
+                .addParameter(PARAM_TOKEN_TYPE, OAuth2AccessToken.BEARER_TYPE)
                 .addParameter(PARAM_EXPIRES_IN, String.valueOf(realmProperties.getTokenLifetime(userRealm.getName()).getSeconds()))
                 .addParameter(PARAM_SCOPE, ScopeService.join(finalScopes))
                 .addParameter(PARAM_STATE, state.orElse(EMPTY_STRING)).build();

--- a/src/main/java/org/zalando/planb/provider/OIDCController.java
+++ b/src/main/java/org/zalando/planb/provider/OIDCController.java
@@ -7,6 +7,7 @@ import com.nimbusds.jose.jwk.JWK;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.web.bind.annotation.*;
 import org.zalando.planb.provider.realms.*;
 
@@ -96,6 +97,7 @@ public class OIDCController {
                 .expiresIn(realmProperties.getTokenLifetime(realmName).getSeconds())
                 .scope(ScopeService.join(scopes))
                 .realm(realmName)
+                .tokenType(OAuth2AccessToken.BEARER_TYPE)
                 .build();
     }
 

--- a/src/main/java/org/zalando/planb/provider/OIDCCreateTokenResponse.java
+++ b/src/main/java/org/zalando/planb/provider/OIDCCreateTokenResponse.java
@@ -22,7 +22,7 @@ public class OIDCCreateTokenResponse {
     private String idToken;
 
     @JsonProperty("token_type")
-    private String tokenType = "Bearer";
+    private String tokenType;
 
     @JsonProperty("expires_in")
     private long expiresIn;

--- a/src/test/java/org/zalando/planb/provider/AbstractOauthTest.java
+++ b/src/test/java/org/zalando/planb/provider/AbstractOauthTest.java
@@ -124,6 +124,11 @@ public class AbstractOauthTest extends AbstractSpringTest {
 
     protected ResponseEntity<OIDCCreateTokenResponse> createToken(String realm, String clientId, String clientSecret,
                                                                 String username, String password, String scope) {
+        return createToken(realm, clientId, clientSecret, username, password, scope, OIDCCreateTokenResponse.class);
+    }
+    protected <RESPONSE> ResponseEntity<RESPONSE> createToken(String realm, String clientId, String clientSecret,
+                                                              String username, String password, String scope,
+                                                              Class<RESPONSE> responseType) {
         MultiValueMap<String, Object> requestParameters = new LinkedMultiValueMap<>();
         requestParameters.add("realm", realm);
         requestParameters.add("grant_type", "password");
@@ -139,7 +144,7 @@ public class AbstractOauthTest extends AbstractSpringTest {
                 .header("Authorization", "Basic " + basicAuth)
                 .body(requestParameters);
 
-        return getRestTemplate().exchange(request, OIDCCreateTokenResponse.class);
+        return getRestTemplate().exchange(request, responseType);
     }
 
     protected String stubCustomerService() {

--- a/src/test/java/org/zalando/planb/provider/AuthorizationCodeGrantFlowIT.java
+++ b/src/test/java/org/zalando/planb/provider/AuthorizationCodeGrantFlowIT.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -359,7 +360,7 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
         assertThat(response.getStatusCode()).isEqualTo(OK);
         assertThat(response.getBody().getScope()).contains("uid");
         assertThat(response.getBody().getScope()).contains("ascope");
-        assertThat(response.getBody().getTokenType()).isEqualTo("Bearer");
+        assertThat(response.getBody().getTokenType()).isEqualTo(OAuth2AccessToken.BEARER_TYPE);
         assertThat(response.getBody().getRealm()).isEqualTo("/services");
 
         assertThat(response.getBody().getAccessToken()).isNotEmpty();

--- a/src/test/java/org/zalando/planb/provider/ImplicitGrantFlowIT.java
+++ b/src/test/java/org/zalando/planb/provider/ImplicitGrantFlowIT.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -104,7 +105,7 @@ public class ImplicitGrantFlowIT extends AbstractOauthTest {
         // http://tools.ietf.org/html/rfc6749#section-4.2.2
         // check required parameters
         assertThat(params).containsKey("access_token");
-        assertThat(params).contains(MapEntry.entry("token_type", "Bearer"));
+        assertThat(params).contains(MapEntry.entry("token_type", OAuth2AccessToken.BEARER_TYPE));
         assertThat(params).contains(MapEntry.entry("expires_in", "3600"));
         assertThat(params).containsKey("scope");
         assertThat(params).containsKey("state");
@@ -142,7 +143,7 @@ public class ImplicitGrantFlowIT extends AbstractOauthTest {
         // http://tools.ietf.org/html/rfc6749#section-4.2.2
         // check required parameters
         assertThat(params).containsKey("access_token");
-        assertThat(params).contains(MapEntry.entry("token_type", "Bearer"));
+        assertThat(params).contains(MapEntry.entry("token_type", OAuth2AccessToken.BEARER_TYPE));
         assertThat(params).contains(MapEntry.entry("expires_in", "3600"));
         assertThat(params).containsKey("scope");
         assertThat(params).containsKey("state");

--- a/src/test/java/org/zalando/planb/provider/ServiceUserAuthenticationIT.java
+++ b/src/test/java/org/zalando/planb/provider/ServiceUserAuthenticationIT.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -83,7 +84,7 @@ public class ServiceUserAuthenticationIT extends AbstractOauthTest {
         assertThat(response.getStatusCode()).isEqualTo(OK);
         final OIDCCreateTokenResponse tokenResponse = response.getBody();
         assertThat(tokenResponse.getScope()).isEqualTo("uid");
-        assertThat(tokenResponse.getTokenType()).isEqualTo("Bearer");
+        assertThat(tokenResponse.getTokenType()).isEqualTo(OAuth2AccessToken.BEARER_TYPE);
         assertThat(tokenResponse.getRealm()).isEqualTo("/services");
         assertThat(tokenResponse.getAccessToken()).isNotEmpty();
         assertThat(tokenResponse.getIdToken()).isNull();
@@ -106,7 +107,7 @@ public class ServiceUserAuthenticationIT extends AbstractOauthTest {
         assertThat(response2.getStatusCode()).isEqualTo(OK);
         final OIDCCreateTokenResponse tokenResponse2 = response2.getBody();
         assertThat(tokenResponse2.getScope()).isEqualTo("uid");
-        assertThat(tokenResponse2.getTokenType()).isEqualTo("Bearer");
+        assertThat(tokenResponse2.getTokenType()).isEqualTo(OAuth2AccessToken.BEARER_TYPE);
         assertThat(tokenResponse2.getRealm()).isEqualTo("/services");
         assertThat(tokenResponse2.getAccessToken()).isNotEmpty();
         assertThat(tokenResponse2.getIdToken()).isNull();


### PR DESCRIPTION
- Added builder call to add token_type in OIDCController
- Removed default value from lombok pojo so it forces clients to add it manually