### PR TITLE
Issue #122: 5XX on requests with malformed Authorization header

### DIFF
--- a/src/main/java/org/zalando/planb/provider/OIDCController.java
+++ b/src/main/java/org/zalando/planb/provider/OIDCController.java
@@ -56,19 +56,25 @@ public class OIDCController {
     /**
      * Get client_id and client_secret from HTTP Basic Auth
      */
-    public static ClientCredentials getClientCredentials(Optional<String> authorization) throws RealmAuthenticationException {
-        String[] basicAuth = authorization
-                .filter(string -> string.toUpperCase().startsWith(BASIC_AUTH_PREFIX.toUpperCase()))
-                .map(string -> string.substring(BASIC_AUTH_PREFIX.length()))
-                .map(BASE_64_DECODER::decode)
-                .map(bytes -> new String(bytes, UTF_8))
-                .map(string -> string.split(":", 2))
-                .filter(array -> array.length == 2)
-                .orElseThrow(() -> new BadRequestException(
-                        "Malformed or missing Authorization header.",
-                        "invalid_client",
-                        "Client authentication failed"));
-        return ClientCredentials.builder().clientId(basicAuth[0]).clientSecret(basicAuth[1]).build();
+    public static ClientCredentials getClientCredentials(Optional<String> authorization) {
+        final BadRequestException badRequest = new BadRequestException(
+                "Malformed or missing Authorization header.",
+                "invalid_client",
+                "Client authentication failed");
+        try {
+            String[] basicAuth = authorization
+                    .filter(string -> string.toUpperCase().startsWith(BASIC_AUTH_PREFIX.toUpperCase()))
+                    .map(string -> string.substring(BASIC_AUTH_PREFIX.length()))
+                    .map(BASE_64_DECODER::decode)
+                    .map(bytes -> new String(bytes, UTF_8))
+                    .map(string -> string.split(":", 2))
+                    .filter(array -> array.length == 2)
+                    .orElseThrow(() -> badRequest);
+
+            return ClientCredentials.builder().clientId(basicAuth[0]).clientSecret(basicAuth[1]).build();
+        } catch (IllegalArgumentException e) {
+            throw badRequest;
+        }
     }
 
     public static ClientCredentials getClientCredentials(Optional<String> authorization, Optional<String> clientId, Optional<String> clientSecret) throws RealmAuthenticationException {

--- a/src/test/java/org/zalando/planb/provider/OIDCControllerTest.java
+++ b/src/test/java/org/zalando/planb/provider/OIDCControllerTest.java
@@ -3,6 +3,8 @@ package org.zalando.planb.provider;
 import org.junit.Test;
 import java.util.Optional;
 
+import static org.junit.Assert.assertEquals;
+
 public class OIDCControllerTest {
 
     @Test(expected = RealmNotFoundException.class)
@@ -11,4 +13,33 @@ public class OIDCControllerTest {
         OIDCController.getRealmName(realms, Optional.empty(), Optional.of("some.header.value"));
     }
 
+    @Test(expected = BadRequestException.class)
+    public void invalidAuthorizationThrowsBadRequest1() {
+        OIDCController.getClientCredentials(Optional.of("Basic NO-SET-AUTHORIZATION"));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void invalidAuthorizationThrowsBadRequest2() {
+        OIDCController.getClientCredentials(Optional.of("invalid_base64"));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void invalidAuthorizationThrowsBadRequest3() {
+        OIDCController.getClientCredentials(Optional.of(""));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void invalidAuthorizationThrowsBadRequest4() {
+        OIDCController.getClientCredentials(Optional.ofNullable(null));
+    }
+
+    @Test
+    public void resilientToIncompleteAuthorizationHeader() {
+        ClientCredentials cred1 = OIDCController.getClientCredentials(Optional.of("Basic dXNlcm5hbWU6"));
+        assertEquals(cred1.getClientId(), "username");
+        assertEquals(cred1.getClientSecret(), "");
+        ClientCredentials cred2 = OIDCController.getClientCredentials(Optional.of("Basic Og=="));
+        assertEquals(cred2.getClientId(), "");
+        assertEquals(cred2.getClientSecret(), "");
+    }
 }


### PR DESCRIPTION
- Checking for Base64 decoding exceptions
- Added some tests for ClientCredentials::getClientCredentials