### PR TITLE
Updated zappr as per compliance rules

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,7 +1,8 @@
 approvals:
-    minimum: 1
-    pattern: "^:\\+1:$"
-    from:
-        # commenter must be a public zalando org member
+  groups:
+    zalando:
+      minimum: 2
+      from:
         orgs:
-          - zalando
+          - "zalando"
+X-Zalando-Team: "foundation"


### PR DESCRIPTION
- added minimum of 2 approvers for code repos
- added owning team
- removed approval pattern to use default one, as recommended