### PR TITLE
consolidate unknown realms in metrics timer

### DIFF
--- a/src/main/java/org/zalando/planb/provider/OIDCController.java
+++ b/src/main/java/org/zalando/planb/provider/OIDCController.java
@@ -216,7 +216,11 @@ public class OIDCController {
                     .map(e -> (RestException) e)
                     .flatMap(RestException::getErrorLocation)
                     .orElse("other");
-            metric.finish("planb.provider.access_token." + trimSlash(realmName) + ".error." + errorType);
+            if (t instanceof RealmNotFoundException) {
+                metric.finish("planb.provider.access_token.unknown-realm.error." + errorType);
+            } else {
+                metric.finish("planb.provider.access_token." + trimSlash(realmName) + ".error." + errorType);
+            }
             throw t;
         }
     }

--- a/src/test/java/org/zalando/planb/provider/AuthorizationCodeGrantFlowIT.java
+++ b/src/test/java/org/zalando/planb/provider/AuthorizationCodeGrantFlowIT.java
@@ -71,6 +71,21 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
     }
 
     @Test
+    public void unknownRealm() {
+        RequestEntity<Void> request = RequestEntity
+                .get(getAuthorizeUrl("code", "/wrong", "testauthcode", "https://myapp.example.org/callback", "mystate"))
+                .build();
+
+        try {
+            getRestTemplate().exchange(request, String.class);
+            fail("GET should have thrown Bad Request");
+        } catch (HttpClientErrorException ex) {
+            assertThat(ex.getStatusCode()).isEqualTo(BAD_REQUEST);
+            assertThat(ex.getResponseBodyAsString()).contains("realm_not_found");
+        }
+    }
+
+    @Test
     public void redirectUriMissing() {
         RequestEntity<Void> request = RequestEntity
                 .get(getAuthorizeUrl("code", "/services", "testclient", "", ""))
@@ -99,7 +114,7 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
 
         RequestEntity<MultiValueMap<String, Object>> request =
                 post(getAuthorizeUrl())
-                .body(requestParameters);
+                        .body(requestParameters);
 
         try {
             getRestTemplate().exchange(request, Void.class);
@@ -128,7 +143,7 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
         RequestEntity<MultiValueMap<String, Object>> request =
                 post(getAuthorizeUrl())
                         .accept(TEXT_HTML)
-                .body(requestParameters);
+                        .body(requestParameters);
 
         ResponseEntity<Void> authResponse = getRestTemplate().exchange(request, Void.class);
 
@@ -147,8 +162,8 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
 
         RequestEntity<MultiValueMap<String, Object>> request2 =
                 post(getAccessTokenUri())
-                .header("Authorization", "Basic " + basicAuth)
-                .body(requestParameters2);
+                        .header("Authorization", "Basic " + basicAuth)
+                        .body(requestParameters2);
 
         try {
             getRestTemplate().exchange(request2, OIDCCreateTokenResponse.class);
@@ -176,7 +191,7 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
         RequestEntity<MultiValueMap<String, Object>> request =
                 post(getAuthorizeUrl())
                         .accept(TEXT_HTML)
-                .body(requestParameters);
+                        .body(requestParameters);
 
         ResponseEntity<Void> authResponse = getRestTemplate().exchange(request, Void.class);
 
@@ -195,8 +210,8 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
 
         RequestEntity<MultiValueMap<String, Object>> request2 =
                 post(getAccessTokenUri())
-                .header("Authorization", "Basic " + basicAuth)
-                .body(requestParameters2);
+                        .header("Authorization", "Basic " + basicAuth)
+                        .body(requestParameters2);
 
         try {
             getRestTemplate().exchange(request2, OIDCCreateTokenResponse.class);
@@ -231,7 +246,7 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
         RequestEntity<MultiValueMap<String, Object>> request =
                 post(getAuthorizeUrl())
                         .accept(APPLICATION_JSON)
-                .body(requestParameters);
+                        .body(requestParameters);
 
         try {
             getRestTemplate().exchange(request, Void.class);
@@ -257,7 +272,7 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
         RequestEntity<MultiValueMap<String, Object>> request =
                 post(getAuthorizeUrl())
                         .accept(TEXT_HTML)
-                .body(requestParameters);
+                        .body(requestParameters);
 
         ResponseEntity<Void> authResponse = getRestTemplate().exchange(request, Void.class);
 
@@ -324,7 +339,7 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
         RequestEntity<MultiValueMap<String, Object>> request =
                 post(getAuthorizeUrl())
                         .accept(TEXT_HTML)
-                .body(requestParameters);
+                        .body(requestParameters);
 
         ResponseEntity<String> loginResponse = getRestTemplate().exchange(request, String.class);
         assertThat(loginResponse.getBody()).contains("value=\"allow\"");
@@ -334,7 +349,7 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
         request =
                 post(getAuthorizeUrl())
                         .accept(TEXT_HTML)
-                .body(requestParameters);
+                        .body(requestParameters);
 
         ResponseEntity<Void> authResponse = getRestTemplate().exchange(request, Void.class);
 
@@ -353,8 +368,8 @@ public class AuthorizationCodeGrantFlowIT extends AbstractOauthTest {
 
         RequestEntity<MultiValueMap<String, Object>> request2 =
                 post(getAccessTokenUri())
-                .header("Authorization", "Basic " + basicAuth)
-                .body(requestParameters2);
+                        .header("Authorization", "Basic " + basicAuth)
+                        .body(requestParameters2);
 
         ResponseEntity<OIDCCreateTokenResponse> response = getRestTemplate().exchange(request2, OIDCCreateTokenResponse.class);
         assertThat(response.getStatusCode()).isEqualTo(OK);

--- a/src/test/java/org/zalando/planb/provider/OIDCCreateTokenIT.java
+++ b/src/test/java/org/zalando/planb/provider/OIDCCreateTokenIT.java
@@ -1,5 +1,6 @@
 package org.zalando.planb.provider;
 
+import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWT;
@@ -12,6 +13,7 @@ import org.jose4j.jwt.consumer.JwtConsumerBuilder;
 import org.jose4j.jwt.consumer.JwtContext;
 import org.jose4j.keys.resolvers.HttpsJwksVerificationKeyResolver;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +37,9 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @ActiveProfiles("it")
 public class OIDCCreateTokenIT extends AbstractOauthTest {
+
+    @Autowired
+    private MetricRegistry metricRegistry;
 
     @Test
     public void createServiceUserToken() {
@@ -274,6 +279,7 @@ public class OIDCCreateTokenIT extends AbstractOauthTest {
         } catch (HttpClientErrorException e) {
             assertThat(e.getStatusCode()).isEqualTo(BAD_REQUEST);
             assertThat(getErrorResponseMap(e)).contains(entry("error", "realm_not_found"));
+            assertThat(metricRegistry.getTimers()).containsKey("planb.provider.access_token.unknown-realm.error.other");
         }
     }
 


### PR DESCRIPTION
When called with unknown realms planb provider will create a metric timer entry for each unknown realm
With this change this is now all consolidated to "unknown-realm".